### PR TITLE
Set rcon shutdown command timeout to 10 seconds

### DIFF
--- a/palword-rcon-monitored.bat
+++ b/palword-rcon-monitored.bat
@@ -86,6 +86,7 @@ call :sendRcon "save"
 
 :: Shutdown command
 call :sendRcon "shutdown 10 Server_Restart_In_10_Seconds"
+timeout /t 30
 
 :: Backup logic just before shutdown
 echo [%date% %time%] Backup server data...

--- a/palword-rcon-monitored.bat
+++ b/palword-rcon-monitored.bat
@@ -65,13 +65,20 @@ exit /b
 :restartServer
 :: Server restart announcements and shutdown logic
 echo [%date% %time%] Announcing server restart...
-call :sendRcon "Broadcast ServerRestartIn5min."
+
+call :sendRcon "Broadcast Server_Restart_In_20_min."
+timeout /t 600
+
+call :sendRcon "Broadcast Server_Restart_In_10_min."
+timeout /t 300
+
+call :sendRcon "Broadcast Server_Restart_In_5_min."
 timeout /t 120
 
-call :sendRcon "Broadcast ServerRestartIn3min."
+call :sendRcon "Broadcast Server_Restart_In_3_min."
 timeout /t 120
 
-call :sendRcon "Broadcast ServerRestartIn1min."
+call :sendRcon "Broadcast Server_Restart_In_1_min."
 timeout /t 60
 
 :: Save the game state before shutting down

--- a/palword-rcon-monitored.bat
+++ b/palword-rcon-monitored.bat
@@ -78,7 +78,7 @@ timeout /t 60
 call :sendRcon "save"
 
 :: Shutdown command
-call :sendRcon "shutdown 0 ServerRestartIn1minLOGOUTNOW."
+call :sendRcon "shutdown 10 Server_Restart_In_10_Seconds"
 
 :: Backup logic just before shutdown
 echo [%date% %time%] Backup server data...


### PR DESCRIPTION
The shutdown RCON command wasn't working for me, I think because 0 isn't accepted as a timeout currently?

Also there are a bunch of 10-minute battles in Palworld so I think a longer warning before the restart.

I was also having an issue with the new server starting before the old one shutdown so I put in a timeout for the old one to shut down.